### PR TITLE
Symmetrical Text Centering

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ venn.js [![Build Status](https://travis-ci.org/benfred/venn.js.svg?branch=master
 
 A javascript library for laying out area proportional venn and euler diagrams.
 
-Details of how this library works can be found on the [blog 
+Details of how this library works can be found on the [blog
 post](http://www.benfrederickson.com/venn-diagrams-with-d3.js/)
 I wrote about this. A follow up post [discusses testing strategy and
 algorithmic improvements](http://www.benfrederickson.com/better-venn-diagrams/).
@@ -22,14 +22,14 @@ diagrams.
 
 ##### Simple layout
 
-To lay out a simple diagram, just define the sets and their sizes along with the sizes 
+To lay out a simple diagram, just define the sets and their sizes along with the sizes
 of all the set intersections.
 
 The VennDiagram object will calculate a layout that is proportional to the
 input sizes, and display it in the appropriate selection when called:
 
 ```javascript
-var sets = [ {sets: ['A'], size: 12}, 
+var sets = [ {sets: ['A'], size: 12},
              {sets: ['B'], size: 12},
              {sets: ['A','B'], size: 2}];
 
@@ -47,7 +47,7 @@ has been drawn. For instance to draw a Venn Diagram with white text and a darker
 ```javascript
 var chart = venn.VennDiagram()
 d3.select("#inverted").datum(sets).call(chart)
-            
+
 d3.selectAll("#inverted .venn-circle path")
     .style("fill-opacity", .8);
 
@@ -56,6 +56,12 @@ d3.selectAll("#inverted text").style("fill", "white");
 
 [View this example, along with other possible styles](http://benfred.github.io/venn.js/examples/styled.html)
 
+The position of text within each circle of the diagram may also be modified via the `symmeticalTextCentre` property (defaults to `false`):
+
+```javascript
+// draw a diagram with text symmetrically positioned in each circle's centre
+var chart = venn.VennDiagram({symmetricalTextCentre: true});
+```
 
 ##### Dynamic layout
 
@@ -120,7 +126,7 @@ div.selectAll("g")
         // Display a tooltip with the current size
         tooltip.transition().duration(400).style("opacity", .9);
         tooltip.text(d.size + " users");
-        
+
         // highlight the current path
         var selection = d3.select(this).transition("tooltip").duration(400);
         selection.select("path")
@@ -133,7 +139,7 @@ div.selectAll("g")
         tooltip.style("left", (d3.event.pageX) + "px")
                .style("top", (d3.event.pageY - 28) + "px");
     })
-    
+
     .on("mouseout", function(d, i) {
         tooltip.transition().duration(400).style("opacity", 0);
         var selection = d3.select(this).transition("tooltip").duration(400);

--- a/examples/styled_centre.html
+++ b/examples/styled_centre.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Venn.js Styling examples</title>
+<style>
+body {
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size: 14px;
+}
+</style>
+</head>
+
+<body>
+    <script src="https://d3js.org/d3.v4.min.js"></script>
+    <script src="../venn.js"></script>
+    <script src="./medical.jsonp"></script>
+
+    <h2>Applying styles to venn diagrams</h2>
+
+    Here are some examples of applying different styles to the same venn diagram,
+    using a dataset from <a
+    href="http://www.cs.uic.edu/~wilkinson/Publications/venneuler.pdf"> this
+    paper</a> . View the source to see the code to generate. </a>
+
+
+    <div id="rings">
+        <script>
+            var chart = venn.VennDiagram({symmetricalTextCentre: true})
+                             .width(500)
+                             .height(500);
+
+            d3.select("#rings").datum(sets).call(chart);
+
+            var colours = ['black', 'red', 'blue', 'green'];
+
+            d3.selectAll("#rings .venn-circle path")
+                .style("fill-opacity", 0)
+                .style("stroke-width", 10)
+                .style("stroke-opacity", .5)
+                .style("stroke", function(d,i) { return colours[i]; });
+
+            d3.selectAll("#rings .venn-circle text")
+                .style("fill", function(d,i) { return colours[i]})
+                .style("font-size", "24px")
+                .style("font-weight", "100");
+
+        </script>
+    </div>
+    <div id="inverted">
+        <script>
+            var chart = venn.VennDiagram({symmetricalTextCentre: true})
+                             .width(500)
+                             .height(500);
+
+            d3.select("#inverted").datum(sets).call(chart)
+
+            d3.selectAll("#inverted .venn-circle path")
+                .style("fill-opacity", .8);
+
+            d3.selectAll("#inverted text").style("fill", "white");
+        </script>
+    </div>
+    <div id="mono">
+        <script>
+            var chart = venn.VennDiagram({symmetricalTextCentre: true})
+                             .width(500)
+                             .height(500);
+
+            d3.select("#mono").datum(sets).call(chart)
+
+            d3.selectAll("#mono .venn-circle path")
+                .style("fill-opacity", 0)
+                .style("stroke-width", 2)
+                .style("stroke", "#444");
+
+            d3.selectAll("#mono text").style("fill", "#444");
+        </script>
+    </div>
+    <div id="dropshadow">
+        <link href='http://fonts.googleapis.com/css?family=Shadows+Into+Light' rel='stylesheet' type='text/css'>
+        <script>
+            var chart = venn.VennDiagram({symmetricalTextCentre: true})
+                             .width(500)
+                             .height(500);
+
+            d3.select("#dropshadow").datum(sets).call(chart);
+
+            var colours = d3.schemeCategory10;
+            var areas = d3.selectAll("#dropshadow g")
+            areas.select("path")
+                .filter(function(d) { return d.sets.length == 1; })
+                .style("fill-opacity", .1)
+                .style("stroke-width", 5)
+                .style("stroke-opacity", .8)
+                .style("fill", function(d,i) { return colours[i]; })
+                .style("stroke", function(d,i) { return colours[i]; });
+
+            areas.select("text").style("fill", "#444")
+                .style("font-family", "Shadows Into Light")
+                .style("font-size", "22px");
+
+          var defs = d3.select("#dropshadow svg").append("defs");
+
+          // from http://stackoverflow.com/questions/12277776/how-to-add-drop-shadow-to-d3-js-pie-or-donut-chart
+          var filter = defs.append("filter")
+              .attr("id", "dropshadowfilter")
+
+          filter.append("feGaussianBlur")
+              .attr("in", "SourceAlpha")
+              .attr("stdDeviation", 4)
+              .attr("result", "blur");
+          filter.append("feOffset")
+              .attr("in", "blur")
+              .attr("dx", 5)
+              .attr("dy", 5)
+              .attr("result", "offsetBlur");
+
+          var feMerge = filter.append("feMerge");
+
+          feMerge.append("feMergeNode")
+              .attr("in", "offsetBlur")
+          feMerge.append("feMergeNode")
+              .attr("in", "SourceGraphic");
+
+          areas.attr("filter", "url(#dropshadowfilter)");
+        </script>
+    </div>
+    <div id="original">
+        <script>
+            var chart = venn.VennDiagram({symmetricalTextCentre: true})
+                             .width(500)
+                             .height(500);
+
+            d3.select("#original").datum(sets).call(chart);
+        </script>
+    </div>
+</body>
+</html>

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -7,7 +7,16 @@ import {nelderMead} from "fmin";
 
 /*global console:true*/
 
-export function VennDiagram() {
+/**
+ * VennDiagram includes an optional `options` parameter containing the following option(s):
+ *
+ * `symmetricalTextCentre: boolean`
+ * Whether to symmetrically center each circle's text horizontally and vertically.
+ * Defaults to `false`.
+ *
+ * @param {object} options
+ */
+export function VennDiagram(options) {
     var width = 600,
         height = 350,
         padding = 15,
@@ -42,6 +51,7 @@ export function VennDiagram() {
         layoutFunction = venn,
         loss = lossFunction;
 
+    options = options || {symmetricalTextCentre: false};
 
     function chart(selection) {
         var data = selection.datum();
@@ -70,7 +80,7 @@ export function VennDiagram() {
             }
 
             circles = scaleSolution(solution, width, height, padding);
-            textCentres = computeTextCentres(circles, data);
+            textCentres = computeTextCentres(circles, data, options);
         }
 
         // Figure out the current label for each set. These can change
@@ -377,7 +387,7 @@ function circleMargin(current, interior, exterior) {
 // compute the center of some circles by maximizing the margin of
 // the center point relative to the circles (interior) after subtracting
 // nearby circles (exterior)
-export function computeTextCentre(interior, exterior) {
+export function computeTextCentre(interior, exterior, options) {
     // get an initial estimate by sampling around the interior circles
     // and taking the point with the biggest margin
     var points = [], i;
@@ -403,7 +413,7 @@ export function computeTextCentre(interior, exterior) {
                 function(p) { return -1 * circleMargin({x: p[0], y: p[1]}, interior, exterior); },
                 [initial.x, initial.y],
                 {maxIterations:500, minErrorDelta:1e-10}).x;
-    var ret = {x: solution[0], y: solution[1]};
+    var ret = {x: options && !options.symmetricalTextCentre ? solution[0] : 0, y: solution[1]};
 
     // check solution, fallback as needed (happens if fully overlapped
     // etc)
@@ -478,7 +488,7 @@ function getOverlappingCircles(circles) {
     return ret;
 }
 
-export function computeTextCentres(circles, areas) {
+export function computeTextCentres(circles, areas, options) {
     var ret = {}, overlapped = getOverlappingCircles(circles);
     for (var i = 0; i < areas.length; ++i) {
         var area = areas[i].sets, areaids = {}, exclude = {};
@@ -501,7 +511,7 @@ export function computeTextCentres(circles, areas) {
                 exterior.push(circles[setid]);
             }
         }
-        var centre = computeTextCentre(interior, exterior);
+        var centre = computeTextCentre(interior, exterior, options);
         ret[area] = centre;
         if (centre.disjoint && (areas[i].size > 0)) {
             console.log("WARNING: area " + area + " not represented on screen");

--- a/venn.js
+++ b/venn.js
@@ -1237,7 +1237,16 @@
 
     /*global console:true*/
 
-    function VennDiagram() {
+    /**
+     * VennDiagram includes an optional `options` parameter containing the following option(s):
+     *
+     * `symmetricalTextCentre: boolean`
+     * Whether to symmetrically center each circle's text horizontally and vertically.
+     * Defaults to `false`.
+     *
+     * @param {object} options
+     */
+    function VennDiagram(options) {
         var width = 600,
             height = 350,
             padding = 15,
@@ -1272,6 +1281,7 @@
             layoutFunction = venn,
             loss = lossFunction;
 
+        options = options || {symmetricalTextCentre: false};
 
         function chart(selection) {
             var data = selection.datum();
@@ -1300,7 +1310,7 @@
                 }
 
                 circles = scaleSolution(solution, width, height, padding);
-                textCentres = computeTextCentres(circles, data);
+                textCentres = computeTextCentres(circles, data, options);
             }
 
             // Figure out the current label for each set. These can change
@@ -1607,7 +1617,7 @@
     // compute the center of some circles by maximizing the margin of
     // the center point relative to the circles (interior) after subtracting
     // nearby circles (exterior)
-    function computeTextCentre(interior, exterior) {
+    function computeTextCentre(interior, exterior, options) {
         // get an initial estimate by sampling around the interior circles
         // and taking the point with the biggest margin
         var points = [], i;
@@ -1633,7 +1643,7 @@
                     function(p) { return -1 * circleMargin({x: p[0], y: p[1]}, interior, exterior); },
                     [initial.x, initial.y],
                     {maxIterations:500, minErrorDelta:1e-10}).x;
-        var ret = {x: solution[0], y: solution[1]};
+        var ret = {x: options && !options.symmetricalTextCentre ? solution[0] : 0, y: solution[1]};
 
         // check solution, fallback as needed (happens if fully overlapped
         // etc)
@@ -1708,7 +1718,7 @@
         return ret;
     }
 
-    function computeTextCentres(circles, areas) {
+    function computeTextCentres(circles, areas, options) {
         var ret = {}, overlapped = getOverlappingCircles(circles);
         for (var i = 0; i < areas.length; ++i) {
             var area = areas[i].sets, areaids = {}, exclude = {};
@@ -1731,7 +1741,7 @@
                     exterior.push(circles[setid]);
                 }
             }
-            var centre = computeTextCentre(interior, exterior);
+            var centre = computeTextCentre(interior, exterior, options);
             ret[area] = centre;
             if (centre.disjoint && (areas[i].size > 0)) {
                 console.log("WARNING: area " + area + " not represented on screen");


### PR DESCRIPTION
I created a fork of `venn.js` so I could modify how text is centered for [ASR-111](https://a57product.atlassian.net/jira/software/projects/ASR/boards/36/backlog?selectedIssue=ASR-111).

Before pushing up code, I ran the following three scripts to ensure everything was compiled and passed the internal tests:
```
npm run pretest
npm run test
npm run prepublish
```

To validate, clone the repo and open `examples/styled_centre.html` to see an example of text centering.

#### Details

The main thing that needed modification was the value of the `x` property in the `ret` variable on L.416 of `src/diagram.js`. I set up an optional parameter to control how that value will be set. If the `symmetricalTextCentre` option is set to `true`, then `x` will have a value of 0 and the text will be symmetrically centered as follows:

![Screen Shot 2019-11-11 at 12 15 14 PM](https://user-images.githubusercontent.com/30540995/68627784-c4aaaa00-0482-11ea-9bd1-4d1284739307.png)

Otherwise, if the option is not specified, then the default centering method will be used:

![Screen Shot 2019-11-11 at 12 12 59 PM](https://user-images.githubusercontent.com/30540995/68627810-d4c28980-0482-11ea-8b06-420c5ee5bebf.png)

I don't really know why the change made to `ret` works. I just experimented with things that seemed relevant to the issue until they worked the way I wanted them to.

Also, I used the UK variant of "centre" rather than "center" because that's the spelling used by the original author.