### PR TITLE
Add `colourScheme` and `textFill` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ d3.selectAll("#rings .venn-circle")
 ```
 [View this example](http://benfred.github.io/venn.js/examples/interactive.html)
 
+The colour scheme for the diagram's circles may also be modified via the `colourScheme` option, and the text within each circle can have its fill modified via the `textFill` option:
+
+```javascript
+var chart = venn.VennDiagram({
+    colourScheme: ["rgb(235, 237, 238)", "#F26250"],
+    textFill: "#FFF",
+});
+```
+
 ##### Adding tooltips
 
 Another common case is adding a tooltip when hovering over the elements in the diagram. The only

--- a/venn.js
+++ b/venn.js
@@ -1240,9 +1240,15 @@
     /**
      * VennDiagram includes an optional `options` parameter containing the following option(s):
      *
-     * `symmetricalTextCentre: boolean`
+     * `colourScheme: Array<String>`
+     * A list of color values to be applied when coloring diagram circles.
+     *
+     * `symmetricalTextCentre: Boolean`
      * Whether to symmetrically center each circle's text horizontally and vertically.
      * Defaults to `false`.
+     *
+     * `textFill: String`
+     * The color to be applied to the text within each circle.
      *
      * @param {object} options
      */
@@ -1257,6 +1263,7 @@
             styled = true,
             fontSize = null,
             orientationOrder = null,
+            symmetricalTextCentre = options && options.symmetricalTextCentre ? options.symmetricalTextCentre : false,
 
             // mimic the behaviour of d3.scale.category10 from the previous
             // version of d3
@@ -1265,7 +1272,9 @@
             // so this is the same as d3.schemeCategory10, which is only defined in d3 4.0
             // since we can support older versions of d3 as long as we don't force this,
             // I'm hackily redefining below. TODO: remove this and change to d3.schemeCategory10
-            colourScheme = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"],
+            colourScheme = options && options.colourScheme ? options.colourScheme : [
+                "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"
+            ],
             colourIndex = 0,
             colours = function(key) {
                 if (key in colourMap) {
@@ -1280,8 +1289,6 @@
             },
             layoutFunction = venn,
             loss = lossFunction;
-
-        options = options || {symmetricalTextCentre: false};
 
         function chart(selection) {
             var data = selection.datum();
@@ -1310,7 +1317,7 @@
                 }
 
                 circles = scaleSolution(solution, width, height, padding);
-                textCentres = computeTextCentres(circles, data, options);
+                textCentres = computeTextCentres(circles, data, symmetricalTextCentre);
             }
 
             // Figure out the current label for each set. These can change
@@ -1378,7 +1385,8 @@
                 .append('g')
                 .attr("class", function(d) {
                     return "venn-area venn-" +
-                        (d.sets.length == 1 ? "circle" : "intersection");
+                        (d.sets.length == 1 ? "circle" : "intersection") +
+                        (d.colour ? " venn-coloured" : "");
                 })
                 .attr("data-venn-sets", function(d) {
                     return d.sets.join("_");
@@ -1393,16 +1401,23 @@
                 .attr("x", width/2)
                 .attr("y", height/2);
 
-
             // apply minimal style if wanted
             if (styled) {
                 enterPath.style("fill-opacity", "0")
                     .filter(function (d) { return d.sets.length == 1; } )
-                    .style("fill", function(d) { return colours(d.sets); })
+                    .style("fill", function(d) {return d.colour ? d.colour : colours(d.sets); })
                     .style("fill-opacity", ".25");
 
                 enterText
-                    .style("fill", function(d) { return d.sets.length == 1 ? colours(d.sets) : "#444"; });
+                    .style("fill", function(d) {
+                        if (d.colour) {
+                            return "#FFF";
+                        }
+                        if (options.textFill) {
+                            return options.textFill;
+                        }
+                        return d.sets.length == 1 ? colours(d.sets) : "#444";
+                    });
             }
 
             // update existing, using pathTween if necessary
@@ -1617,7 +1632,7 @@
     // compute the center of some circles by maximizing the margin of
     // the center point relative to the circles (interior) after subtracting
     // nearby circles (exterior)
-    function computeTextCentre(interior, exterior, options) {
+    function computeTextCentre(interior, exterior, symmetricalTextCentre) {
         // get an initial estimate by sampling around the interior circles
         // and taking the point with the biggest margin
         var points = [], i;
@@ -1643,7 +1658,7 @@
                     function(p) { return -1 * circleMargin({x: p[0], y: p[1]}, interior, exterior); },
                     [initial.x, initial.y],
                     {maxIterations:500, minErrorDelta:1e-10}).x;
-        var ret = {x: options && !options.symmetricalTextCentre ? solution[0] : 0, y: solution[1]};
+        var ret = {x: symmetricalTextCentre ? 0 : solution[0], y: solution[1]};
 
         // check solution, fallback as needed (happens if fully overlapped
         // etc)
@@ -1718,7 +1733,7 @@
         return ret;
     }
 
-    function computeTextCentres(circles, areas, options) {
+    function computeTextCentres(circles, areas, symmetricalTextCentre) {
         var ret = {}, overlapped = getOverlappingCircles(circles);
         for (var i = 0; i < areas.length; ++i) {
             var area = areas[i].sets, areaids = {}, exclude = {};
@@ -1741,7 +1756,7 @@
                     exterior.push(circles[setid]);
                 }
             }
-            var centre = computeTextCentre(interior, exterior, options);
+            var centre = computeTextCentre(interior, exterior, symmetricalTextCentre);
             ret[area] = centre;
             if (centre.disjoint && (areas[i].size > 0)) {
                 console.log("WARNING: area " + area + " not represented on screen");


### PR DESCRIPTION
For ASR, I needed to be able to set the default bubble colors (both background color and text color)  directly within venn.js. Otherwise, attempting to add colors after the chart has already been constructed results in brief flashes of the initial color appearing on each re-rendering of the chart.

I cannot really show the working result on Netlify until this PR is merged in here, and I update the installed fork on my ASR branch. However, here's a GIF of everything working as it should (might take some time load properly, as it's 1.6MB):

![2019-11-18 15-23-54 2019-11-18 15_26_37](https://user-images.githubusercontent.com/30540995/69108719-a5c78d00-0a19-11ea-81f6-257b7c0e8940.gif)
